### PR TITLE
Add highlighting support for 256-color console Vim

### DIFF
--- a/after/syntax/lua.vim
+++ b/after/syntax/lua.vim
@@ -67,6 +67,6 @@ syntax match lovefunction "\<love\.\%(timer\.\%(getAverageDelta\|getDelta\|getFP
 syntax match lovefunction "\<love\.\%(touch\.\%(getPosition\|getPressure\|getTouches\)\)\>"
 syntax match lovefunction "\<love\.\%(video\.\%(newVideoStream\)\)\>"
 syntax match lovefunction "\<love\.\%(window\.\%(close\|fromPixels\|getDisplayName\|getFullscreen\|getFullscreenModes\|getIcon\|getMode\|getPixelScale\|getPosition\|getTitle\|hasFocus\|hasMouseFocus\|isCreated\|isDisplaySleepEnabled\|isVisible\|maximize\|minimize\|requestAttention\|setDisplaySleepEnabled\|setFullscreen\|setIcon\|setMode\|setPosition\|setTitle\|showMessageBox\|toPixels\)\)\>"
-highlight lovefunction guifg=#ff60e2
-highlight lovetype guifg=#ff60e2
-highlight loveconf guifg=#ff60e2
+highlight lovefunction guifg=#ff60e2 ctermfg=206
+highlight lovetype guifg=#ff60e2 ctermfg=206
+highlight loveconf guifg=#ff60e2 ctermfg=206

--- a/src/syntax/main.lua
+++ b/src/syntax/main.lua
@@ -79,8 +79,8 @@ local function extractData( tab, index )
 end
 extractData( api )
 
-print( 'highlight lovefunction guifg=#ff60e2' )
-print( 'highlight lovetype guifg=#ff60e2' )
-print( 'highlight loveconf guifg=#ff60e2' )
+print( 'highlight lovefunction guifg=#ff60e2 ctermfg=206' )
+print( 'highlight lovetype guifg=#ff60e2 ctermfg=206' )
+print( 'highlight loveconf guifg=#ff60e2 ctermfg=206' )
 
 love.event.quit()


### PR DESCRIPTION
This will allow others who use Vim in the terminal (at least, the ones with 256-color support, which is most of them) to see LÖVE functions highlighted beautifully without having to change any settings.

Color 206 is what Fish gives me as the closest color to `#ff60e2`. On my
computer, it shows up as `#f15be7`.
