### PR TITLE
Use concealed lrv- and love- prefixes; wrap <> for unknown

### DIFF
--- a/src/doc/main.lua
+++ b/src/doc/main.lua
@@ -13,6 +13,18 @@ local TOC_NAME_REF_SPACING = 2
 local TOC_REF_WIDTH_LIMIT = PAGE_WIDTH - TOC_NAME_WIDTH_LIMIT - TOC_NAME_REF_SPACING
 
 local LOVE_TYPES = {}
+
+local LUA_TYPES = {
+	['boolean']        = '|lrv-boolean|',
+	['function']       = '|lrv-function|',
+	['nil']            = '|lrv-nil|',
+	['number']         = '|lrv-number|',
+	['string']         = '|lrv-string|',
+	['table']          = '|lrv-table|',
+	['thread']         = '|lrv-thread|',
+	['userdata']       = '|lrv-userdata|',
+	['light userdata'] = '|lrv-lightuserdata|',
+}
 -- }}}
 
 -- Misc. functions {{{
@@ -58,9 +70,11 @@ end
 
 local function formatAsType( str )
 	if LOVE_TYPES[str] then
-		return ('|%s|'):format( str )
+		return ('|love-%s|'):format( str )
+	elseif LUA_TYPES[str] then
+		return LUA_TYPES[str]
 	else
-		return ('|lrv-%s|'):format( str )
+		return ('<%s>'):format( str )
 	end
 end
 

--- a/src/syntax/gen.bat
+++ b/src/syntax/gen.bat
@@ -14,6 +14,9 @@ REM Update after\syntax
 rd /q /s ..\..\after\syntax
 mkdir ..\..\after\syntax
 
+REM Copy nongenerated help syntax
+copy help.vim ..\..\after\syntax\.
+
 REM Create syntax files
 !lua! lua\main.lua > ..\..\after\syntax\lua.vim
 !lua! love-conf\main.lua > ..\..\after\syntax\love-conf.vim

--- a/src/syntax/gen.sh
+++ b/src/syntax/gen.sh
@@ -15,6 +15,9 @@ cp -rf love-api lua
 rm -rf ../../after/syntax
 mkdir -p ../../after/syntax
 
+# Copy nongenerated help syntax
+cp help.vim ../../after/syntax/.
+
 # Create syntax files
 $lua lua/main.lua > ../../after/syntax/lua.vim
 $lua love-conf/main.lua > ../../after/syntax/love-conf.vim

--- a/src/syntax/help.vim
+++ b/src/syntax/help.vim
@@ -1,0 +1,27 @@
+" Help extensions for vim-love-docs
+" This is based on luarefvim
+
+" Only apply syntax changes to our help docs (which will actually contain
+" these prefixes).
+if -1 == stridx(resolve(expand('%:p')), resolve(expand("<sfile>:p:h:h:h") .'/doc/'))
+    finish
+endif
+
+syn clear helpHyperTextJump
+" helpHyperTextJump copied from $VIMRUNTIME/ftplugin/help.vim
+if has("ebcdic")
+    syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar,helpHideLrv,helpHideLove
+else
+    syn match helpHyperTextJump	"\\\@<!|[#-)!+-~]\+|" contains=helpBar,helpHideLrv,helpHideLove
+endif
+
+if has("conceal")
+    syn match helpHideLrv		contained "\<lrv-" conceal
+    syn match helpHideLove		contained "\<love-" conceal
+else
+    syn match helpHideLrv		contained "\<lrv-"
+    syn match helpHideLove		contained "\<love-"
+endif
+
+hi def link helpHideLrv         Ignore
+hi def link helpHideLove        Ignore


### PR DESCRIPTION
Resolves #19 by building on davisdude's work.

This resolves the No links for love types and Nontypes formatted as types issues I found. I didn't attempt to resolve the issue with Aggregate or multiple possible types.

Adding after/syntax/help.vim required bypassing gitignore. Not sure if you want an alternative solution. I didn't test any syntax changes (I don't use the syntax features of vim-love-docs).